### PR TITLE
Point the user towards multiple_linear_regression if they use nd-y

### DIFF
--- a/slisemap/local_models.py
+++ b/slisemap/local_models.py
@@ -22,6 +22,13 @@ def linear_regression(X: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
     Returns:
         torch.Tensor: Prediction tensor [n_b, n_x, 1]
     """
+    _assert(
+        X.shape[1] == B.shape[1],
+        "The B matrix has too many columns\n\
+        Did you mean to use `multiple_linear_regression` \
+        for a multidimensional Y?",
+    )
+
     return (B @ X.T)[:, :, None]
 
 

--- a/slisemap/local_models.py
+++ b/slisemap/local_models.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 from torch.nn.functional import softmax
 
-from slisemap.utils import _assert
+from slisemap.utils import _assert, _assert_no_trace
 
 
 def linear_regression(X: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
@@ -22,8 +22,8 @@ def linear_regression(X: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
     Returns:
         torch.Tensor: Prediction tensor [n_b, n_x, 1]
     """
-    _assert(
-        X.shape[1] == B.shape[1],
+    _assert_no_trace(
+        lambda: X.shape[1] == B.shape[1],
         "The B matrix has too many columns\n\
         Did you mean to use `multiple_linear_regression` \
         for a multidimensional Y?",

--- a/slisemap/local_models.py
+++ b/slisemap/local_models.py
@@ -24,7 +24,7 @@ def linear_regression(X: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
     """
     _assert_no_trace(
         lambda: X.shape[1] == B.shape[1],
-        "The B matrix has too many columns\n\
+        "The B matrix does not have the same number of columns as X.\n\
         Did you mean to use `multiple_linear_regression` \
         for a multidimensional Y?",
     )

--- a/slisemap/utils.py
+++ b/slisemap/utils.py
@@ -8,6 +8,7 @@ from warnings import warn
 
 import numpy as np
 import torch
+import warnings
 
 
 class SlisemapException(Exception):
@@ -23,6 +24,12 @@ class SlisemapWarning(Warning):
 def _assert(condition: bool, message: str):
     if not condition:
         raise SlisemapException(message)
+
+
+def _assert_no_trace(condition: Callable[[], bool], message: str):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=torch.jit.TracerWarning)
+        _assert(condition(), message)
 
 
 def _warn(warning: str, method: Optional[Callable] = None):

--- a/tests/test_local_models.py
+++ b/tests/test_local_models.py
@@ -1,4 +1,6 @@
+import pytest
 from slisemap.local_models import *
+from slisemap.utils import SlisemapException
 
 from .utils import *
 
@@ -23,6 +25,8 @@ def test_linear_model():
     assert L.shape == (10, 10)
     L = linear_regression_loss(Y, Y)
     assert L.shape == (10,)
+    with pytest.raises(SlisemapException, match=r"multiple_linear_regression"):
+        linear_regression(X, B)
 
 
 def test_logistic_model():


### PR DESCRIPTION
Adds a helpful error message hint if someone tries to use a multidimensional `Y` with `linear_regression`